### PR TITLE
Add width and height parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__
+images
+modes

--- a/CXH_PhotoMaker.py
+++ b/CXH_PhotoMaker.py
@@ -39,7 +39,9 @@ class CXH_PhotoMaker:
                 "base_model_path": ("STRING", {"default": "SG161222/RealVisXL_V3.0","multiline": False}),             
                 "positive": ("STRING", {"default": "UHD, 8K, ultra detailed, a cinematic photograph of a girl img wearing the sunglasses in Iron man suit , beautiful lighting, great composition","multiline": True}),
                 "negative": ("STRING", {"default": "ugly, deformed, noisy, blurry, NSFW", "multiline": True}),
-                "seed": ("INT", {"default": 0, "min": 0, "max": 99999999}),       
+                "seed": ("INT", {"default": 0, "min": 0, "max": 99999999}),
+                "width": ("INT", {"default": 1024, "min": 512, "max": 2048}),
+                "height": ("INT", {"default": 1024, "min": 512, "max": 2048}),     
                 }
         }
 
@@ -58,7 +60,9 @@ class CXH_PhotoMaker:
                 base_model_path,
                 positive,
                 negative,
-                seed):
+                seed,
+                width,
+                height):
         
         if self.pipe == None or self.cur_model_path == None or self.cur_model_path != base_model_path:
             self.pipe = PhotoMakerStableDiffusionXLPipeline.from_pretrained(
@@ -100,6 +104,8 @@ class CXH_PhotoMaker:
             start_merge_step=start_merge_step,
             generator=generator,
             guidance_scale=guidance_scale,
+            width=width,
+            height=height
         ).images
         
         return (pil2tensor(images[0]),num_images)

--- a/CXH_PhotoMaker.py
+++ b/CXH_PhotoMaker.py
@@ -40,8 +40,8 @@ class CXH_PhotoMaker:
                 "positive": ("STRING", {"default": "UHD, 8K, ultra detailed, a cinematic photograph of a girl img wearing the sunglasses in Iron man suit , beautiful lighting, great composition","multiline": True}),
                 "negative": ("STRING", {"default": "ugly, deformed, noisy, blurry, NSFW", "multiline": True}),
                 "seed": ("INT", {"default": 0, "min": 0, "max": 99999999}),
-                "width": ("INT", {"default": 1024, "min": 512, "max": 2048}),
-                "height": ("INT", {"default": 1024, "min": 512, "max": 2048}),     
+                "width": ("INT", {"default": 1024, "min": 512, "max": 2048, "step": 32}),
+                "height": ("INT", {"default": 1024, "min": 512, "max": 2048, "step": 32}),     
                 }
         }
 

--- a/CXH_PhotoMaker_Batch.py
+++ b/CXH_PhotoMaker_Batch.py
@@ -45,7 +45,9 @@ class CXH_PhotoMaker_Batch:
                 "base_model_path": ("STRING", {"default": "SG161222/RealVisXL_V3.0","multiline": False}),             
                 "positive": ("STRING", {"default": "UHD, 8K, ultra detailed, a cinematic photograph of a girl img wearing the sunglasses in Iron man suit , beautiful lighting, great composition","multiline": True}),
                 "negative": ("STRING", {"default": "ugly, deformed, noisy, blurry, NSFW", "multiline": True}),
-                "seed": ("INT", {"default": 0, "min": 0, "max": 99999999}),       
+                "seed": ("INT", {"default": 0, "min": 0, "max": 99999999}),
+                "width": ("INT", {"default": 1024, "min": 512, "max": 2048}),
+                "height": ("INT", {"default": 1024, "min": 512, "max": 2048}),   
                 }
         }
 
@@ -66,7 +68,9 @@ class CXH_PhotoMaker_Batch:
                 base_model_path,
                 positive,
                 negative,
-                seed):
+                seed,
+                width,
+                height):
         
         if self.pipe == None or self.cur_model_path == None or self.cur_model_path != base_model_path:
             self.pipe = PhotoMakerStableDiffusionXLPipeline.from_pretrained(
@@ -112,6 +116,8 @@ class CXH_PhotoMaker_Batch:
             start_merge_step=start_merge_step,
             generator=generator,
             guidance_scale=guidance_scale,
+            width=width,
+            height=height
         ).images
         
         if open_save == 1:

--- a/CXH_PhotoMaker_Batch.py
+++ b/CXH_PhotoMaker_Batch.py
@@ -46,8 +46,8 @@ class CXH_PhotoMaker_Batch:
                 "positive": ("STRING", {"default": "UHD, 8K, ultra detailed, a cinematic photograph of a girl img wearing the sunglasses in Iron man suit , beautiful lighting, great composition","multiline": True}),
                 "negative": ("STRING", {"default": "ugly, deformed, noisy, blurry, NSFW", "multiline": True}),
                 "seed": ("INT", {"default": 0, "min": 0, "max": 99999999}),
-                "width": ("INT", {"default": 1024, "min": 512, "max": 2048}),
-                "height": ("INT", {"default": 1024, "min": 512, "max": 2048}),   
+                "width": ("INT", {"default": 1024, "min": 512, "max": 2048, "step": 32}),
+                "height": ("INT", {"default": 1024, "min": 512, "max": 2048, "step": 32}),   
                 }
         }
 

--- a/CXH_PhotoMaker_Batch.py
+++ b/CXH_PhotoMaker_Batch.py
@@ -95,8 +95,9 @@ class CXH_PhotoMaker_Batch:
         generator = torch.Generator(device=device).manual_seed(seed)
         
         image_basename_list = os.listdir(dir_path)
-        image_path_list = sorted([os.path.join(dir_path, basename) for basename in image_basename_list])
-        
+        image_path_list = [os.path.join(dir_path, basename) for basename in image_basename_list if os.path.isfile(os.path.join(dir_path, basename))]
+        image_path_list = sorted(image_path_list)
+
         input_id_images = []
         for image_path in image_path_list:
             input_id_images.append(load_image(image_path))


### PR DESCRIPTION
This PR add the ability to create non square aspect ratio output images:

![image](https://github.com/StartHua/Comfyui-Mine-PhotoMaker/assets/7474674/8db22ced-f626-4177-8e41-2735ea168ce4)

I also fixed an issue where the batch node would fail to load images if a folder was present alongside the images. The new version will only look for files and disregard non files in a folder.